### PR TITLE
SIG-1755 WFDS-4.3.1.1 "generate_randnum"

### DIFF
--- a/python/myutils.py
+++ b/python/myutils.py
@@ -905,7 +905,7 @@ def process_cmd(line):
         destmac,55:44:33:22:11:00)
     """
     global conntable, threadCount, waitsocks_par, runningPhase, testRunning, streamInfoArray, streamInfoArrayTemp, resultPrinted
-    global retValueTable, RTPCount, multicast, ifcondBit, iDNB, iINV, ifCondBit, tidx, socktimeout
+    global retValueTable, RTPCount, multicast, ifcondBit, iDNB, iINV, ifCondBit, tidx, socktimeout, oplist
     global tmsPacket
     line = line.rstrip()
     str = line.split('#')


### PR DESCRIPTION
Added missing commit which should be in 9.2.0 release
oplist is not define prior to use,
its already defined globally, so added in global list of the process_cmd

# Conflicts:
#	python/myutils.py